### PR TITLE
Use servo_move function rather than copying code

### DIFF
--- a/autobearduino.ino
+++ b/autobearduino.ino
@@ -4,11 +4,28 @@ Servo myservo;
 char serialData;
 boolean animate = false;
 
-int val = 0;
-int count = 0;
-int pose;
+byte count = 0;
+byte pose_n;
 
-void setup() {
+struct pose {
+  byte from;
+  byte to_boundary;
+  byte step;
+  byte delay;
+};
+
+pose poses[][2] = {
+    // from, to_boundary, step, delay
+    // first is down, second is up
+    { {80, 1, 4, 18}, {5, 90, 10, 18} },
+    { {129, 3, 5, 18}, {5, 110, 10, 18} },
+    { {170, 3, 3, 8}, {3, 90, 9, 18} },
+    { {90, 3, 5, 18}, {3, 90, 10, 18} },
+    { {130, 1, 3, 18}, {1, 130, 10, 18} },
+};
+
+void setup() 
+{
     myservo.attach(9);
     myservo.write(90);
     Serial.begin(9600);
@@ -19,7 +36,8 @@ void setup() {
     }
 }
 
-void serialEvent() {
+void serialEvent() 
+{
     while (Serial.available()) {
         serialData = (char) Serial.read();
         if (serialData == 'g') {
@@ -30,56 +48,32 @@ void serialEvent() {
     }
 }
 
-void loop() {
+void servo_move(pose pose_down, pose pose_up)
+{
+    byte val = 0;
+
+    for (val = pose_down.from; val >= pose_down.to_boundary; val -= pose_down.step) {
+        myservo.write(val);
+        delay(pose_down.delay);
+    }
+
+    for (val = pose_up.from; val <= pose_up.to_boundary; val += pose_up.step) {
+        myservo.write(val);
+        delay(pose_up.delay);
+    }
+}
+
+void loop() 
+{
     if (animate) {
-        count++;
-        pose = count % 5;
-        
-        if (pose == 4) {
-            for (val = 130; val >= 1; val -= 3) {
-                myservo.write(val);
-                delay(18);
-            }
-            for (val = 1; val <= 130; val += 10) {
-                myservo.write(val);
-                delay(18);
-            }
-        } else if (pose == 3) {
-            for (val = 90; val >= 3; val -= 5) {
-                myservo.write(val);
-                delay(18);
-            }
-            for (val = 3; val <= 90; val += 10) {
-                myservo.write(val);
-                delay(18);
-            }
-        } else if (pose == 2) {
-            for (val = 170; val >= 3; val -= 3) {
-                myservo.write(val);
-                delay(8);
-            }
-            for (val = 3; val <= 90; val += 9) {
-                myservo.write(val);
-                delay(18);
-            }
-        } else if (pose == 1) {
-            for (val = 129; val >= 3; val -= 5) {
-                myservo.write(val);
-                delay(18);
-            }
-            for (val = 5; val <= 110; val += 10) {
-                myservo.write(val);
-                delay(18);
-            }
-        } else if (pose == 0) {
-            for (val = 80; val >= 1; val -= 4) {
-                myservo.write(val);
-                delay(18);
-            }
-            for (val = 5; val <= 90; val += 10) {
-                myservo.write(val);
-                delay(18);
-            }
+        if (count == 255) {
+            count = 0;
         }
+
+        pose_n = count % 5;
+
+        servo_move(poses[pose_n][0], poses[pose_n][1]);
+
+        count++;
     }
 }

--- a/autobearduino.ino
+++ b/autobearduino.ino
@@ -14,7 +14,7 @@ struct pose {
   byte delay;
 };
 
-pose poses[][2] = {
+const pose poses[][2] = {
     // from, to_boundary, step, delay
     // first is down, second is up
     { {80, 1, 4, 18}, {5, 90, 10, 18} },


### PR DESCRIPTION
As title says / see the code.

I've actually tested this on an Arduino - with nothing connected. So I know it compiles and does something, but please test on the bear if it really works.

Went from
```
Sketch uses 3834 bytes (12%) of program storage space. Maximum is 30720 bytes.
Global variables use 235 bytes (11%) of dynamic memory, leaving 1813 bytes for local variables. Maximum is 2048 bytes.
```
to
```
Sketch uses 3248 bytes (10%) of program storage space. Maximum is 30720 bytes.
Global variables use 271 bytes (13%) of dynamic memory, leaving 1777 bytes for local variables. Maximum is 2048 bytes.
```

Also, I've noticed that one delay is 8 and all the others are 18 - is that correct?